### PR TITLE
Add CMake project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #
 cmake_minimum_required(VERSION 2.8)
-project(Boost.DI CXX)
+project(Boost.DI VERSION 1.1.0 LANGUAGES CXX)
 set(CXX_STANDARD 14 CACHE STRING "C++ Standard Version. [14|17|20]")
 
 add_library(${PROJECT_NAME} INTERFACE)


### PR DESCRIPTION
Problem:
Without project version cmake tools such as hunter work incorrectly.

Solution:
Add version.